### PR TITLE
Improved Test and Brew Audit Fixes

### DIFF
--- a/Formula/mos-latest.rb
+++ b/Formula/mos-latest.rb
@@ -5,9 +5,10 @@ class MosLatest < Formula
   desc "Mongoose OS command-line tool (latest)"
   homepage "https://mongoose-os.com/"
   url "https://github.com/mongoose-os/mos/archive/d2abac8cbc0fab748d18ff0ebd01e23cd895e547.tar.gz"
-  sha256 "5a1847c3b76adcdcbc6dc17f4aaff700d5810f193589f7684857027ae3b8c756"
   version "202012121701"
-  head ""
+  sha256 "5a1847c3b76adcdcbc6dc17f4aaff700d5810f193589f7684857027ae3b8c756"
+  license "Apache-2.0"
+  head "https://github.com/mongoose-os/mos.git"
 
   bottle do
     root_url "https://mongoose-os.com/downloads/homebrew/bottles-mos-latest"
@@ -16,17 +17,15 @@ class MosLatest < Formula
   end
   # update_hb end
 
-  head "https://github.com/mongoose-os/mos.git"
-
-  depends_on "libftdi"
-  depends_on "libusb"
-  depends_on "libusb-compat"
   depends_on "go" => :build
   depends_on "make" => :build
   depends_on "pkg-config" => :build
   depends_on "python3" => :build
+  depends_on "libftdi"
+  depends_on "libusb"
+  depends_on "libusb-compat"
 
-  conflicts_with "mos", :because => "Use mos or mos-latest, not both"
+  conflicts_with "mos", because: "use mos or mos-latest, not both"
 
   def install
     cd buildpath do
@@ -44,6 +43,12 @@ class MosLatest < Formula
   end
 
   test do
-    system bin/"mos", "version"
+    # Remove (latest) and hyphen
+    test_desc = desc[0...desc.rindex(" ")].tr("-", " ")
+    expected = "#{test_desc}\n"   \
+    "Version: #{version}\n"       \
+    "Build ID: #{version}~brew\n" \
+    "Update channel: latest\n"
+    assert_match expected, shell_output("#{bin}/mos version")
   end
 end

--- a/Formula/mos.rb
+++ b/Formula/mos.rb
@@ -4,10 +4,14 @@ class Mos < Formula
   # update_hb begin
   desc "Mongoose OS command-line tool"
   homepage "https://mongoose-os.com/"
-  url "https://github.com/mongoose-os/mos/archive/1ec85951e77649f1151bc06a12901faa784a991a.tar.gz"
-  sha256 "1d95538be29219a487ec21724f65ca9e4ab28341e2a722ac6dd6abd249560583"
-  version "2.18.0"
-  head ""
+  url "https://github.com/mongoose-os/mos/archive/2.18.0.tar.gz"
+  sha256 "46fa3902878dee9e21a94b2686b084f90f517a9175aa20b81d984811b227ef56"
+  license "Apache-2.0"
+  head "https://github.com/mongoose-os/mos.git"
+
+  livecheck do
+    url :stable
+  end
 
   bottle do
     root_url "https://mongoose-os.com/downloads/homebrew/bottles-mos"
@@ -16,17 +20,15 @@ class Mos < Formula
   end
   # update_hb end
 
-  head "https://github.com/mongoose-os/mos.git"
-
-  depends_on "libftdi"
-  depends_on "libusb"
-  depends_on "libusb-compat"
   depends_on "go" => :build
   depends_on "make" => :build
   depends_on "pkg-config" => :build
-  depends_on "python3" => :build
+  depends_on "python@3.9" => :build
+  depends_on "libftdi"
+  depends_on "libusb"
+  depends_on "libusb-compat"
 
-  conflicts_with "mos-latest", :because => "Use mos or mos-latest, not both"
+  conflicts_with "mos-latest", because: "use mos or mos-latest, not both"
 
   def install
     cd buildpath do
@@ -44,6 +46,11 @@ class Mos < Formula
   end
 
   test do
-    system bin/"mos", "version"
+    test_desc = desc.tr("-", " ")
+    expected = "#{test_desc}\n"   \
+    "Version: #{version}\n"       \
+    "Build ID: #{version}~brew\n" \
+    "Update channel: release\n"
+    assert_match expected, shell_output("#{bin}/mos version")
   end
 end


### PR DESCRIPTION
I tried to get the formulae to the same standards as if they were in [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core). This involved doing the following:

* Improving the rigour of the test
* Using the new Ruby 1.9 hash syntax
* Applying general brew audit corrections

I have tried to not get in the way of the [`update_hb.py`](https://github.com/mongoose-os/mos/blob/master/tools/update_hb.py) script, but let me know if I need to correct anything. Thanks.